### PR TITLE
add rotations support in merge endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,11 @@ run-server:
 CONTAINER_REGISTRY=ghcr.io/ant31/$(package)
 
 
-docker-push-local: docker-build-locall
-    docker push $(CONTAINER_REGISTRY):latest
+docker-push-local: docker-build-local
+	docker push $(CONTAINER_REGISTRY):latest
 
 docker-build-local:
-    docker build --network=host -t $(CONTAINER_REGISTRY):latest .
+	docker build --network=host -t $(CONTAINER_REGISTRY):latest .
 
 docker-push:
 	docker buildx build --push -t $(CONTAINER_REGISTRY):latest .

--- a/pdfserve/pdf.py
+++ b/pdfserve/pdf.py
@@ -311,6 +311,7 @@ class PdfTransform:
         tmpdir: str | None = None,
         use_temporary: bool = True,
         dpi: int = 96,
+        rotations: Sequence[int] | None = None,
     ):
         self.dpi = dpi
         self._input_files = files
@@ -319,6 +320,7 @@ class PdfTransform:
         self.use_temporary = use_temporary
         self._loaded = False
         self._files = []
+        self._rotations = list(rotations) if rotations else []
 
     def reload(self):
         self._files = []
@@ -342,17 +344,28 @@ class PdfTransform:
         return ""
 
     async def load(
-        self, fileinput: PDFInput | PdfFileInfo | Image, dest_dir: str = "", use_temporary: bool = True
+        self,
+        fileinput: PDFInput | PdfFileInfo | Image,
+        dest_dir: str = "",
+        use_temporary: bool = True,
+        rotate: int = 0,
     ) -> PdfFileInfo:
         if isinstance(fileinput, str | Path):
-            info = await self.download_file(fileinput, dest_dir=dest_dir, use_temporary=use_temporary)
+            info = await self.download_file(
+                fileinput, dest_dir=dest_dir, use_temporary=use_temporary, rotate=rotate
+            )
         elif isinstance(fileinput, Image):
             info = PdfFileInfo(
-                filename=self._img_filename(fileinput), source=self._img_filename(fileinput), image=fileinput
+                filename=self._img_filename(fileinput),
+                source=self._img_filename(fileinput),
+                image=fileinput,
+                rotate=rotate,
             )
         elif isinstance(fileinput, IOBase):
-            info = PdfFileInfo(filename="", content=fileinput)
+            info = PdfFileInfo(filename="", content=fileinput, rotate=rotate)
         elif isinstance(fileinput, PdfFileInfo):
+            if rotate:
+                fileinput.rotate = rotate
             info = await self.load_image(fileinput)
         else:
             raise ValueError(f"Invalid file type: {type(fileinput)}")
@@ -366,7 +379,9 @@ class PdfTransform:
             raise ValueError(f"Invalid file: {info}, missing content or path or pdf")
         return info
 
-    async def download_file(self, source: str | Path, dest_dir: str = "", use_temporary: bool = True) -> PdfFileInfo:
+    async def download_file(
+        self, source: str | Path, dest_dir: str = "", use_temporary: bool = True, rotate: int = 0
+    ) -> PdfFileInfo:
         tmp = Path("")
         if use_temporary:
             tmp = tempfile.SpooledTemporaryFile(dir=self.tmpdir)  # pylint: disable=consider-using-with
@@ -377,6 +392,7 @@ class PdfTransform:
             path=Path(str(finfo.path)),
             content=finfo.content,
             image=None,
+            rotate=rotate,
         )
         return await self.load_image(p)
 
@@ -393,6 +409,8 @@ class PdfTransform:
             # Skip non-image files
             logger.debug("Failed to open image: %s", e)
         if pdfinfo.image:
+            if pdfinfo.rotate:
+                pdfinfo.image = pdfinfo.image.rotate(-pdfinfo.rotate, expand=True)
             pdfinfo.pdf = self._img_to_pdf(pdfinfo.image, None, scale=pdfinfo.scale, dpi=self.dpi)
         return pdfinfo
 
@@ -403,12 +421,14 @@ class PdfTransform:
         res = []
         n = 5
         split_list = [files[i * n : (i + 1) * n] for i in range((len(files) + n - 1) // n)]
+        index = 0
         for split_files in split_list:
-            res.append(
-                await asyncio.gather(
-                    *[self.load(f, dest_dir=dest_dir, use_temporary=use_temporary) for f in split_files]
-                )
-            )
+            tasks = []
+            for f in split_files:
+                rotate = self._rotations[index] if index < len(self._rotations) else 0
+                tasks.append(self.load(f, dest_dir=dest_dir, use_temporary=use_temporary, rotate=rotate))
+                index += 1
+            res.append(await asyncio.gather(*tasks))
         return [x for subres in res for x in subres]
 
     async def merge(

--- a/pdfserve/server/api/pdf.py
+++ b/pdfserve/server/api/pdf.py
@@ -125,6 +125,15 @@ async def merge_pdf(
     ] = "",
     dpi: Annotated[int, Query(description="DPI to use for input images")] = 96,
     outline: Annotated[bool, Query(description="create an outline with the name of the file as items")] = True,
+    rotations: Annotated[
+        list[int] | None,
+        Query(
+            description=(
+                "per-file clockwise rotation in degrees, aligned by index with files. "
+                "If provided, must have the same length as files. Only applied to images."
+            )
+        ),
+    ] = None,
 ) -> FileResponse:
     """
     Merge pdf files into one.
@@ -132,14 +141,20 @@ async def merge_pdf(
     - **name**: the name of the merged file, if not provided, a random name will be generated
     - **files**: a list of files to merge, can be a list of URL to download the file from or the uploaded file as binary object
     - **outline**: if True, create an outline with the name of the file, if False, no outline will be added
+    - **rotations**: optional per-file clockwise rotation in degrees, aligned by index with files
     """
     if files is None:
         files = []
     inputs = prepare_files(files)
+    if rotations and len(rotations) != len(inputs):
+        raise HTTPException(
+            status_code=422,
+            detail=f"rotations length ({len(rotations)}) must match files length ({len(inputs)})",
+        )
     logger.info("Merging: %s, outline: %s", str(inputs), outline)
     with tempfile.NamedTemporaryFile(suffix=".pdf", mode="w+b", delete=False) as tmpf:
         background_tasks.add_task(cleanup, tmpf)
-        pt = PdfTransform(files=inputs, dest_dir="", use_temporary=True, dpi=dpi)
+        pt = PdfTransform(files=inputs, dest_dir="", use_temporary=True, dpi=dpi, rotations=rotations)
         output = await pt.merge(name=name, output=tmpf.file, outline=outline)
         if output is None:
             raise ValueError("No output")

--- a/tests/test_pdf_rotate.py
+++ b/tests/test_pdf_rotate.py
@@ -1,0 +1,84 @@
+import asyncio
+from io import BytesIO
+
+import PIL.Image
+import pytest
+from fastapi import BackgroundTasks
+from fastapi.exceptions import HTTPException
+
+from pdfserve.pdf import PdfFileInfo, PdfTransform
+
+
+def _png_bytes(width: int, height: int) -> BytesIO:
+    buf = BytesIO()
+    PIL.Image.new("RGB", (width, height), color=(255, 0, 0)).save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
+def test_load_image_rotate_90_swaps_dimensions():
+    info = PdfFileInfo(filename="a.png", content=_png_bytes(100, 50), rotate=90)
+    pt = PdfTransform(files=[])
+
+    result = asyncio.run(pt.load_image(info))
+
+    assert result.image is not None
+    assert result.image.size == (50, 100)
+    assert result.pdf is not None
+
+
+def test_load_image_rotate_zero_is_noop():
+    info = PdfFileInfo(filename="a.png", content=_png_bytes(100, 50), rotate=0)
+    pt = PdfTransform(files=[])
+
+    result = asyncio.run(pt.load_image(info))
+
+    assert result.image is not None
+    assert result.image.size == (100, 50)
+
+
+def test_load_image_rotate_180_keeps_dimensions():
+    info = PdfFileInfo(filename="a.png", content=_png_bytes(100, 50), rotate=180)
+    pt = PdfTransform(files=[])
+
+    result = asyncio.run(pt.load_image(info))
+
+    assert result.image is not None
+    assert result.image.size == (100, 50)
+
+
+def test_pdftransform_applies_rotations_by_index():
+    info = PdfFileInfo(filename="a.png", content=_png_bytes(100, 50))
+    pt = PdfTransform(files=[info], rotations=[90])
+
+    loaded = asyncio.run(pt.files)
+
+    assert loaded[0].image.size == (50, 100)
+
+
+def test_pdftransform_without_rotations_leaves_image_untouched():
+    info = PdfFileInfo(filename="a.png", content=_png_bytes(100, 50))
+    pt = PdfTransform(files=[info])
+
+    loaded = asyncio.run(pt.files)
+
+    assert loaded[0].image.size == (100, 50)
+
+
+def test_merge_rejects_rotations_length_mismatch():
+    try:
+        from pdfserve.server.api.pdf import merge_pdf
+    except TypeError as exc:  # pragma: no cover
+        pytest.skip(f"router import blocked by pre-existing fastapi/pydantic incompatibility: {exc}")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            merge_pdf(
+                BackgroundTasks(),
+                files=["https://example.com/a.png", "https://example.com/b.png"],
+                rotations=[90],
+            )
+        )
+
+    assert exc.value.status_code == 422
+    assert "rotations length" in exc.value.detail


### PR DESCRIPTION
sample existing curl call:
```shell
curl -X POST "http://localhost:8080/api/v1/pdf/merge" \
  -F "files=@localfilepath/aaaaa.png" \
  -F "files=https://images.unsplash.com/photo-1501785888041-af3ef285b470" \
  --output merged_local.pdf
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1381k  100 1087k  100  293k   386k   104k  0:00:02  0:00:02 --:--:--  491k
```

logs:
```shell
INFO:     Merging: [PdfFileInfo(filename='aaaaa.png', content=<tempfile.SpooledTemporaryFile object at 0xffff9e7abaf0>, path=None, source=None, image=None, scale=1, rotate=0, pdf=None), 'https://images.unsplash.com/photo-1501785888041-af3ef285b470'], outline: True
INFO:     download https://images.unsplash.com/photo-1501785888041-af3ef285b470, /photo-1501785888041-af3ef285b470
INFO:     Merging: [<tempfile.SpooledTemporaryFile object at 0xffff9e7aa380>, <tempfile.SpooledTemporaryFile object at 0xffff9e84fe50>], outline: ['aaaaa.png', 'photo-1501785888041-af3ef285b470']
INFO:     192.168.65.1:39633 - "POST /api/v1/pdf/merge HTTP/1.1" 200 OK
```

passing rotations in the request params:
```shell
curl -X POST "http://localhost:8080/api/v1/pdf/merge?rotations=180&rotations=270" \
  -F "files=@localfilepath/aaaaa.png" \
  -F "files=https://images.unsplash.com/photo-1501785888041-af3ef285b470" \
  --output merged_local.pdf
```

logs:
```shell
INFO:     Merging: [PdfFileInfo(filename='aaaaa.png', content=<tempfile.SpooledTemporaryFile object at 0xffff9e84c3d0>, path=None, source=None, image=None, scale=1, rotate=0, pdf=None), 'https://images.unsplash.com/photo-1501785888041-af3ef285b470'], outline: True
INFO:     download https://images.unsplash.com/photo-1501785888041-af3ef285b470, /photo-1501785888041-af3ef285b470
INFO:     Merging: [<tempfile.SpooledTemporaryFile object at 0xffff9e838af0>, <tempfile.SpooledTemporaryFile object at 0xffff9e83b1c0>], outline: ['aaaaa.png', 'photo-1501785888041-af3ef285b470']
INFO:     192.168.65.1:28490 - "POST /api/v1/pdf/merge?rotations=180&rotations=270 HTTP/1.1" 200 OK
```